### PR TITLE
fix: async_setup_entry to use async_forward_entry_setups

### DIFF
--- a/custom_components/foxess_tseries/__init__.py
+++ b/custom_components/foxess_tseries/__init__.py
@@ -8,8 +8,6 @@ async def async_setup_entry(
     hass.data[DOMAIN][entry.entry_id] = entry.data
 
     # Forward the setup to the sensor platform.
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "sensor")
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
 
     return True

--- a/custom_components/foxess_tseries/manifest.json
+++ b/custom_components/foxess_tseries/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "name": "FoxESS T Series",
   "requirements": [],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
And bump version to 1.0.1

Should fix the issue I mentioned [here](https://github.com/LucasTor/FoxESS-T-series/issues/6)

(I should mention that HA is not giving warning/error with this fix but I have to wait until tomorrow when inverter turns back on again to properly test it)