### PR TITLE
add buttons for HACS installation section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,25 @@ The integration now supports both RS485 TCP Bridges as well as RS485 USB Adapter
 
 To connect your inverter to either adapter (TCP or USB), on the newer models, please refer to [this guide](https://github.com/LucasTor/FoxESS-T-series/issues/2#issuecomment-2088445998), for older models, a RS485 comm port should be found on one of the connectors on the inverter.
 ## Installation
+[![Add Integration](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=foxess_tseries)
+[![Add Repository](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=LucasTor&repository=FoxEss-T-series&category=integration)
 
-Please use HACS to install it :)
+### HACS Installation (Recommended)
+
+1. Make sure you have [HACS](https://hacs.xyz/) installed
+2. Add this repository as a custom repository in HACS:
+   - Go to HACS > Integrations
+   - Click on the three dots in the top right corner
+   - Select "Custom repositories"
+   - Add the URL of this repository
+   - Select "Integration" as the category
+3. Click "Install" on the FoxEss-T-series integration
+
+### Manual Installation
+
+1. Copy the `custom_components/foxess_tseries` directory to your Home Assistant `custom_components` directory
+2. Restart Home Assistant
+
 
 ## Configuring the payload version
 


### PR DESCRIPTION
Added installation instructions for HACS and manual methods. And added buttons for configuration/installation of integration

To clear up confusion like [this](https://github.com/LucasTor/FoxESS-T-series/issues/8#issue-3484697073) and to be more in-line with other projects.